### PR TITLE
UI scroll body table

### DIFF
--- a/components/ui/phone-field/index.ts
+++ b/components/ui/phone-field/index.ts
@@ -1,0 +1,1 @@
+export { default } from './phone-field';

--- a/components/ui/table/body/body.styled.tsx
+++ b/components/ui/table/body/body.styled.tsx
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+
+const Cell = (props: { 'data-type': string }) => {
+  switch (props['data-type']) {
+    case 'thumbnail':
+      return `
+        height: 59px;
+        width: 106px;
+        > img {
+          height: 48px;
+          vertical-align: middle
+          width: 96px;
+        }
+      `;
+    case 'text':
+      return `
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 0;
+      `;
+    case 'title':
+      return `
+        color: #ffffff;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 0;
+      `;
+    case 'button':
+      return `
+        width: 1%;
+      `;
+  }
+};
+
+export const Td = styled.td`
+  color: #000000;
+  border-bottom: 1px solid #cccccc;
+  padding: 5px;
+  white-space: nowrap;
+  ${(props) => Cell(props as any)};
+`;
+
+export const Tr = styled.tr`
+  cursor: pointer;
+  &:hover {
+    background-color: #fff000;
+    a {
+      opacity: 1;
+    }
+  }
+`;

--- a/components/ui/table/body/body.tsx
+++ b/components/ui/table/body/body.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import * as Styled from './body.styled';
+import Button from '@/components/ui/button';
+
+interface Props {
+  item: {
+    date: string;
+  };
+}
+
+const AnnotationItem: React.FC<Props> = ({
+  item,
+}) => {
+  return (
+    <Styled.Tr>
+      <Styled.Td>item.date</Styled.Td>
+      <Styled.Td data-type="thumbnail"><img src={'dummy-image'} /></Styled.Td>
+      <Styled.Td data-type="text">name</Styled.Td>
+      <Styled.Td data-type="text">dummy name</Styled.Td>
+      <Styled.Td data-type="title">dummy title</Styled.Td>
+      <Styled.Td data-type="button"><Button>button</Button></Styled.Td>
+    </Styled.Tr>
+  );
+};
+
+export default AnnotationItem;

--- a/components/ui/table/body/index.ts
+++ b/components/ui/table/body/index.ts
@@ -1,0 +1,3 @@
+export { default } from './body';
+// eslint-disable-next-line prettier/prettier
+export type { Props } from './body';

--- a/components/ui/table/index.ts
+++ b/components/ui/table/index.ts
@@ -1,0 +1,1 @@
+export { default } from './table-container';

--- a/components/ui/table/table-container.tsx
+++ b/components/ui/table/table-container.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import Table from './table';
+import * as Styled from './table.styled';
+
+const TableContainer: React.FC = () => {
+  const items = [
+    { date: '2021/01/01'},
+    { date: '2021/01/02'},
+    { date: '2021/01/03'},
+    { date: '2021/01/04'},
+    { date: '2021/01/05'},
+  ];
+
+  return (
+    <Styled.TableWrapper>
+      <Table items={items} />
+    </Styled.TableWrapper>
+  );
+};
+
+export default TableContainer;

--- a/components/ui/table/table.styled.tsx
+++ b/components/ui/table/table.styled.tsx
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+
+export const TableWrapper = styled.div`
+  max-height: 300px;
+  overflow-y: auto;
+`;
+
+export const Table = styled.table`
+  background-color: #ffffff;
+  border-collapse: collapse;
+  font-size: 1rem;
+  width: 100%;
+`;
+
+export const Th = styled.th`
+  background-color: #ffffff;
+  border-bottom: 1px solid #cccccc;
+  color: #000000;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding-bottom: 0.625rem;
+  position: sticky;
+  text-align: left;
+  top: 0;
+  word-break: keep-all;
+  z-index: 10;
+
+  ::before {
+    border-bottom: 1px solid #cccccc;
+    content: '';
+    height: 100%;
+    left: -1px;
+    position: absolute;
+    top: 1px;
+    width: 100%;
+  }
+`;

--- a/components/ui/table/table.tsx
+++ b/components/ui/table/table.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import * as Styled from './table.styled';
+import Body from './body';
+
+interface Props {
+  items: { [key: string]: string }[];
+}
+
+const Table: React.FC<Props> = ({
+  items,
+}) => {
+
+  return (
+    <Styled.Table>
+      <thead>
+        <tr>
+          <Styled.Th style={{ width: '6rem' }}>2000/01/23</Styled.Th>
+          <Styled.Th>Dummy Dummy</Styled.Th>
+          <Styled.Th>Dummy Dummy</Styled.Th>
+          <Styled.Th>Dummy Dummy</Styled.Th>
+          <Styled.Th>Dummy Dummy</Styled.Th>
+          <Styled.Th style={{ width: '1%' }}>Dummy Dummy</Styled.Th>
+        </tr>
+      </thead>
+      <tbody>
+        {items && items.map((item, i) => {
+          return (
+            <Body
+              key={i}
+              item={item}
+            />
+          );
+        })}
+      </tbody>
+    </Styled.Table>
+  );
+};
+
+Table.displayName = 'Table';
+
+export default Table;


### PR DESCRIPTION
# Table ヘッダーを残してTable Body をスクロールする

- Body のリスト内の文字列がセル幅以上ある場合は ... で省略する

```css
overflow: hidden;
text-overflow: ellipsis;
max-width: 0;
```
